### PR TITLE
Switch from connection -> crypton-connection and build with GHC 9.6.3

### DIFF
--- a/kubernetes-client/kubernetes-client.cabal
+++ b/kubernetes-client/kubernetes-client.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -52,8 +52,12 @@ library
     , base >=4.7 && <5.0
     , base64-bytestring
     , bytestring >=0.10
-    , connection >=0.3
     , containers >=0.5
+    , crypton-connection
+    , crypton-x509 >=1.7
+    , crypton-x509-store >=1.6
+    , crypton-x509-system >=1.6
+    , crypton-x509-validation >=1.6
     , data-default-class >=0.1
     , either >=5.0
     , filepath >=1.4
@@ -77,10 +81,6 @@ library
     , tls >=1.4.1
     , typed-process >=0.2
     , uri-bytestring >=0.3
-    , x509 >=1.7
-    , x509-store >=1.6
-    , x509-system >=1.6
-    , x509-validation >=1.6
     , yaml >=0.8.32
   default-language: Haskell2010
 
@@ -99,8 +99,12 @@ test-suite example
     , base >=4.7 && <5.0
     , base64-bytestring
     , bytestring >=0.10
-    , connection >=0.3
     , containers >=0.5
+    , crypton-connection
+    , crypton-x509 >=1.7
+    , crypton-x509-store >=1.6
+    , crypton-x509-system >=1.6
+    , crypton-x509-validation >=1.6
     , data-default-class >=0.1
     , either >=5.0
     , filepath >=1.4
@@ -125,10 +129,6 @@ test-suite example
     , tls >=1.4.1
     , typed-process >=0.2
     , uri-bytestring >=0.3
-    , x509 >=1.7
-    , x509-store >=1.6
-    , x509-system >=1.6
-    , x509-validation >=1.6
     , yaml >=0.8.32
   default-language: Haskell2010
 
@@ -152,8 +152,12 @@ test-suite spec
     , base >=4.7 && <5.0
     , base64-bytestring
     , bytestring >=0.10
-    , connection >=0.3
     , containers >=0.5
+    , crypton-connection
+    , crypton-x509 >=1.7
+    , crypton-x509-store >=1.6
+    , crypton-x509-system >=1.6
+    , crypton-x509-validation >=1.6
     , data-default-class >=0.1
     , either >=5.0
     , file-embed
@@ -182,9 +186,5 @@ test-suite spec
     , tls >=1.4.1
     , typed-process >=0.2
     , uri-bytestring >=0.3
-    , x509 >=1.7
-    , x509-store >=1.6
-    , x509-system >=1.6
-    , x509-validation >=1.6
     , yaml
   default-language: Haskell2010

--- a/kubernetes-client/package.yaml
+++ b/kubernetes-client/package.yaml
@@ -43,8 +43,8 @@ dependencies:
   - aeson >=1.2 && <3
   - attoparsec >=0.13
   - jsonpath >=0.1 && <0.4
-  - connection >=0.3
   - containers >= 0.5
+  - crypton-connection
   - data-default-class >=0.1
   - either >=5.0
   - filepath >=1.4
@@ -67,8 +67,8 @@ dependencies:
   - tls >=1.4.1
   - typed-process >=0.2
   - uri-bytestring >=0.3
-  - x509 >=1.7
-  - x509-system >=1.6
-  - x509-store >=1.6
-  - x509-validation >=1.6
+  - crypton-x509 >=1.7
+  - crypton-x509-system >=1.6
+  - crypton-x509-store >=1.6
+  - crypton-x509-validation >=1.6
   - yaml >=0.8.32

--- a/kubernetes-client/src/Kubernetes/Client/Auth/OIDC.hs
+++ b/kubernetes-client/src/Kubernetes/Client/Auth/OIDC.hs
@@ -61,7 +61,9 @@ instance AuthMethod OIDCAuth where
       & L.set rAuthTypesL []
 
 data OIDCGetTokenException =
-#if MIN_VERSION_hoauth2(2,8,0)
+#if MIN_VERSION_hoauth2(2,9,0)
+  OIDCOAuthException TokenResponseError
+#elif MIN_VERSION_hoauth2(2,8,0)
   OIDCOAuthException TokenRequestError
 #else
   OIDCOAuthException (OAuth2Error OAuth2TokenRequest.Errors)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,11 @@
-resolver: lts-21.0
+resolver: lts-22.6
 
 packages:
 - kubernetes
 - kubernetes-client
+
+extra-deps:
+- oidc-client-0.7.0.1@sha256:557341f7521e62c09abddf0d06c8e8acce119d3a9a4c4ffac1ab8ca3fc0e5067,3382
+
+# - git: https://github.com/codedownio/haskell-oidc-client
+#   commit: 3cb40ba3abfc9a030f31cc2f919bfc192f7e9f5e

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,17 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: oidc-client-0.7.0.1@sha256:557341f7521e62c09abddf0d06c8e8acce119d3a9a4c4ffac1ab8ca3fc0e5067,3382
+    pantry-tree:
+      sha256: 51cfcd6c170923db24ba297ac9937961f6b26e041ceec8ff09500e61017b433b
+      size: 1298
+  original:
+    hackage: oidc-client-0.7.0.1@sha256:557341f7521e62c09abddf0d06c8e8acce119d3a9a4c4ffac1ab8ca3fc0e5067,3382
 snapshots:
 - completed:
-    sha256: 1867d84255dff8c87373f5dd03e5a5cb1c10a99587e26c8793e750c54e83ffdc
-    size: 639139
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/0.yaml
-  original: lts-21.0
+    sha256: 1b4c2669e26fa828451830ed4725e4d406acc25a1fa24fcc039465dd13d7a575
+    size: 714100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/6.yaml
+  original: lts-22.6


### PR DESCRIPTION
The `connection` package has been archived and dependent packages are switching to `crypton-connection`.

See https://discourse.haskell.org/t/fork-of-archived-connection-a-k-a-hs-connection-library/8545/5

This switch allows `kubernetes-client-haskell` to build against the latest Stackage LTSes with GHC 9.6.